### PR TITLE
docs: 修复第7章客户端代码示例错误

### DIFF
--- a/docs/ch7.md
+++ b/docs/ch7.md
@@ -1263,7 +1263,7 @@ get manager() {return this._department.manager;}
 #### 客户端代码...
 
 ```js
-manager = aPerson.department.manager;
+manager = aPerson.manager();
 ```
 
 只要完成了对 Department 所有函数的修改，并相应修改了 Person 的所有客户端，我就可以移除 Person 中的 department 访问函数了。


### PR DESCRIPTION
将示例代码从直接访问department属性改为调用manager()方法，
与前文的重构逻辑保持一致。